### PR TITLE
internal/transformer: Reduce some multi-value calc expressions

### DIFF
--- a/internal/transformer/math_test.go
+++ b/internal/transformer/math_test.go
@@ -36,13 +36,18 @@ func TestMath(t *testing.T) {
 
 	assert.Equal(t, `.class{width:calc(1px+2px)}`, Transform(t, nil, `.class { width: calc(1px + 2px) }`))
 
-	// XXX: this should work but doesn't. because we treat math as left-associative and binary but
-	// 22% - 1rem cannot be reduced into something that can be added to 8rem.
-	// assert.Equal(t, `.class{width:calc(22%+7rem)}`, Transform(t, compileMath, `.class { width: calc(22% - 1rem + 8rem) }`))
+	assert.Equal(t, `.class{width:calc(22%+2rem)}`, Transform(t, compileMath, `.class { width: calc(22% + 1rem + 1rem) }`)) // +
+	assert.Equal(t, `.class{width:calc(22%-2rem)}`, Transform(t, compileMath, `.class { width: calc(22% - 1rem - 1rem) }`)) // +
+	assert.Equal(t, `.class{width:22%}`, Transform(t, compileMath, `.class { width: calc(22% + 1rem - 1rem) }`))            // -
+	assert.Equal(t, `.class{width:calc(22%-7rem)}`, Transform(t, compileMath, `.class { width: calc(22% + 1rem - 8rem) }`)) // -
+	assert.Equal(t, `.class{width:calc(22%+7rem)}`, Transform(t, compileMath, `.class { width: calc(22% - 1rem + 8rem) }`)) // -
+	// XXX: this should work but doesn't.
+	// assert.Equal(t, `.class{width:calc(7rem+22%)}`, Transform(t, compileMath, `.class { width: calc(8rem + 22% - 1rem) }`))
+
+	// + -4px
+	// assert.Equal(t, `.class{width:calc(22%-9rem)}`, Transform(t, compileMath, `.class { width: calc(22% - 1rem + -8rem) }`)) // -
+	// assert.Equal(t, `.class{width:calc(22%+7rem)}`, Transform(t, compileMath, `.class { width: calc(22% - 1rem - -8rem) }`)) // -
 
 	// XXX: does this one work?
 	// calc(var(--x) + 5px)
-	// ((5px + 22%) + 5px)
-	// (((5px + 22%) + 5px) + 5px) = 22% + 15px
-	// (((5px + 22%) + 22%) + 5px) = 44% + 10px
 }


### PR DESCRIPTION
The calc reducer can now reduce expressions of the form
calc(100% - 1px - 1px), where the second and third values are the same
unit but the first isn't. It can also reduce calc(100% + 1px - 1px) to
calc(100%).

The reducer can no longer handle expressions of the form
calc(100% - 1px - -1px), where a negative value is subtracted. It also
can't reduce expressions where the first and third values are the same
type, but the second isn't.